### PR TITLE
Fixed links on About page

### DIFF
--- a/councilmatic/customizations/templates/about.html
+++ b/councilmatic/customizations/templates/about.html
@@ -25,17 +25,17 @@
                 <p>Councilmatic Chicago lets you search, browse, subscribe and comment on everything the City Council has done since Jan 1st 2010. Some interesting searches include:</p>
 
                 <ul>
-                    <li><a href="http://councilmatic.opencityapps.org/search/?q=zoning+reclassification">changes in zoning</a></li>
-                    <li><a href="http://councilmatic.opencityapps.org/search/?q=settlement&file_types=Report">what the city is paying out in settlements</a></li>
-                    <li><a href='http://councilmatic.opencityapps.org/legislation/906492'>committee appointments</a></li>
-                    <li><a href="http://councilmatic.opencityapps.org/search/?q=birthday">birthdays</a></li>
+                    <li><a href="http://chicagocouncilmatic.org/search/?q=zoning+reclassification">changes in zoning</a></li>
+                    <li><a href="http://chicagocouncilmatic.org/search/?q=settlement&file_types=Report">what the city is paying out in settlements</a></li>
+                    <li><a href='http://chicagocouncilmatic.org/legislation/906492'>committee appointments</a></li>
+                    <li><a href="http://chicagocouncilmatic.org/search/?q=birthday">birthdays</a></li>
                 </ul>
 
                 <p>
                 You can also see and follow all the legislation sponsored by your alderman or mayor
-                (<a href="http://councilmatic.opencityapps.org/search/?q=&sponsors=Bob+Fioretti">Bob Fioretti</a>,
-                 <a href="http://councilmatic.opencityapps.org/search/?q=&sponsors=Leslie+A.+Hairston">Leslie Hairston</a>,
-                 <a href="http://councilmatic.opencityapps.org/search/?q=&sponsors=Rahm+Emanuel">Rahm Emanuel</a>).
+                (<a href="http://chicagocouncilmatic.org/search/?q=&sponsors=Bob+Fioretti">Bob Fioretti</a>,
+                 <a href="http://chicagocouncilmatic.org/search/?q=&sponsors=Leslie+A.+Hairston">Leslie Hairston</a>,
+                 <a href="http://chicagocouncilmatic.org/search/?q=&sponsors=Rahm+Emanuel">Rahm Emanuel</a>).
                 </p>
 
                 <p>If you want to keep tabs on an issue or topic, you can <strong>subscribe</strong> (<i class='icon-star'></i>) to each ordinance or resolution, and if something new happens with it, you will get an e-mail notification.</p>
@@ -90,7 +90,7 @@
                 <h3 id='contact-us'>Contact us</h3>
                     <p>
                       Found a bug?
-                      <a href='https://github.com/open-city/second-city-zoning/issues?state=open'>Report it on our issue tracker!</a>
+                      <a href='https://github.com/open-city/councilmatic/issues?state=open'>Report it on our issue tracker!</a>
                     </p>
                     <p>
                       Have a suggestion or feedback? Contact us at


### PR DESCRIPTION
Corrected the link to the github issue tracker. Also updated search example links to be chicagocouncilmatic.org instead of councilmatic.opencityapps.org
