### PR TITLE
Add Council Member name to detail page title

### DIFF
--- a/councilmatic/templates/councilmatic/councilmember_detail.html
+++ b/councilmatic/templates/councilmatic/councilmember_detail.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load compress %}
 {% load cache %}
-
+{% block title %}{{ councilmember.name }} | {{ site.name }}{% endblock %}
 {% block load_early %}
 {% endblock %}
 


### PR DESCRIPTION
Attempt to partially fix #59 by adding councilmember_detail.html Title "{{ councilmember.name }} | {{ site.name }}".

Having trouble with my install so I can't properly test this. 

Does it make sense to include ward number in the Title too?
